### PR TITLE
feat: [005-Popoularity-Post] 실시간 인기게시글 기능 구현

### DIFF
--- a/common/src/main/java/com/project/common/domain/dto/PostEvent.java
+++ b/common/src/main/java/com/project/common/domain/dto/PostEvent.java
@@ -1,0 +1,16 @@
+package com.project.common.domain.dto;
+
+import com.project.common.domain.entity.PostEventType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostEvent {
+  private Long postId;
+  private Long userId;
+  private PostEventType type;
+  private Long timestamp;
+}

--- a/common/src/main/java/com/project/common/domain/entity/PostEventType.java
+++ b/common/src/main/java/com/project/common/domain/entity/PostEventType.java
@@ -1,0 +1,5 @@
+package com.project.common.domain.entity;
+
+public enum PostEventType {
+  VIEW,LIKE,COMMENT
+}

--- a/post-api/build.gradle
+++ b/post-api/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // JSON 직렬화를 위한 의존성 추가 부분!
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/post-api/src/main/java/com/project/post/PopularPostDto.java
+++ b/post-api/src/main/java/com/project/post/PopularPostDto.java
@@ -1,0 +1,14 @@
+package com.project.post;
+
+import com.project.common.domain.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+//Api전용 Dto
+@Getter
+@AllArgsConstructor
+public class PopularPostDto {
+  private final Post post;
+  private final double score;
+}

--- a/post-api/src/main/java/com/project/post/config/PopularityKafkaConfig.java
+++ b/post-api/src/main/java/com/project/post/config/PopularityKafkaConfig.java
@@ -1,0 +1,41 @@
+package com.project.post.config;
+
+import com.project.common.domain.dto.PostEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class PopularityKafkaConfig {
+
+  @Bean
+  public ConsumerFactory<String, PostEvent> popConsumerFactory() {
+    Map<String, Object> props = new HashMap<>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, "popularity-group");
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+    props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.project.common.dto");
+    return new DefaultKafkaConsumerFactory<>(
+        props,
+        new StringDeserializer(),
+        new JsonDeserializer<>(PostEvent.class, false)
+    );
+  }
+
+  //알림을 위한 Listener와 이름 다르게 생성
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, PostEvent> popKafkaListenerContainerFactory() {
+    var factory = new ConcurrentKafkaListenerContainerFactory<String, PostEvent>();
+    factory.setConsumerFactory(popConsumerFactory());
+    return factory;
+  }
+}

--- a/post-api/src/main/java/com/project/post/config/PopularityProducerConfig.java
+++ b/post-api/src/main/java/com/project/post/config/PopularityProducerConfig.java
@@ -1,0 +1,35 @@
+package com.project.post.config;
+
+import com.project.common.domain.dto.PostEvent;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class PopularityProducerConfig {
+
+  @Bean
+  public ProducerFactory<String, PostEvent> postEventProducerFactory() {
+    Map<String, Object> props = new HashMap<>();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+        org.springframework.kafka.support.serializer.JsonSerializer.class);
+
+    props.put("spring.json.trusted.packages", "com.project.common.dto");
+    return new DefaultKafkaProducerFactory<>(props);
+  }
+
+  @Bean
+  @Qualifier("popularityKafkaTemplate")
+  public KafkaTemplate<String, PostEvent> popularityKafkaTemplate(
+      ProducerFactory<String, PostEvent> postEventProducerFactory) {
+    return new KafkaTemplate<>(postEventProducerFactory);
+  }
+}

--- a/post-api/src/main/java/com/project/post/config/PopularityRedisConfig.java
+++ b/post-api/src/main/java/com/project/post/config/PopularityRedisConfig.java
@@ -1,0 +1,30 @@
+package com.project.post.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class PopularityRedisConfig {
+
+  @Bean("popularityRedisTemplate")
+  public RedisTemplate<String, Object> popularityRedisTemplate(RedisConnectionFactory cf) {
+    var om = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    var serializer = new GenericJackson2JsonRedisSerializer(om);
+
+    RedisTemplate<String, Object> rt = new RedisTemplate<>();
+    rt.setConnectionFactory(cf);
+    rt.setKeySerializer(new StringRedisSerializer());
+    rt.setValueSerializer(serializer);
+    rt.afterPropertiesSet();
+    return rt;
+  }
+}

--- a/post-api/src/main/java/com/project/post/controller/PopularPostController.java
+++ b/post-api/src/main/java/com/project/post/controller/PopularPostController.java
@@ -1,0 +1,65 @@
+package com.project.post.controller;
+
+import com.project.common.domain.entity.Post;
+import com.project.common.domain.repository.PostRepository;
+import com.project.post.PopularPostDto;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PopularPostController {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final PostRepository postRepository;
+
+  @GetMapping("/popular")
+  public List<PopularPostDto> getPopularPosts(
+      @RequestParam(defaultValue = "10") int size
+  ) {
+    String zkey = "popular-posts";
+
+    // Redis 에서 score 높은 순으로 가져옴
+    Set<ZSetOperations.TypedTuple<Object>> tuples = redisTemplate.opsForZSet()
+        .reverseRangeWithScores(zkey, 0, size - 1);
+
+    if (tuples == null || tuples.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    // Redis 결과에서 postId와 score 따로 분리
+    List<Long> postIds = tuples.stream()
+        .map(t -> Long.valueOf((String) t.getValue()))
+        .collect(Collectors.toList());
+
+    Map<Long, Double> scoreMap = tuples.stream()
+        .collect(Collectors.toMap(
+            t -> Long.valueOf((String) t.getValue()),
+            ZSetOperations.TypedTuple::getScore
+        ));
+
+    // 디비에서 해당 게시글들 한 번에 조회
+    List<Post> posts = postRepository.findAllById(postIds);
+
+    //원래 순서 high -> low 대로 dto 리스트 생성
+    return postIds.stream()
+        .map(id -> {
+          Post p = posts.stream()
+              .filter(x -> x.getId().equals(id))
+              .findFirst()
+              .orElse(null);
+          return new PopularPostDto(p, scoreMap.get(id));
+        })
+        .filter(dto -> dto.getPost() != null)
+        .collect(Collectors.toList());
+  }
+}

--- a/post-api/src/main/java/com/project/post/service/PopularityEventListener.java
+++ b/post-api/src/main/java/com/project/post/service/PopularityEventListener.java
@@ -1,0 +1,37 @@
+package com.project.post.service;
+
+import com.project.common.domain.dto.PostEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PopularityEventListener {
+
+  private final @Qualifier("popularityRedisTemplate")
+  RedisTemplate<String, Object> popularityRedisTemplate;
+
+
+  @KafkaListener(
+      topics = "post-events",
+      groupId = "popularity-group",
+      containerFactory = "popKafkaListenerContainerFactory"
+  )
+  public void handlePostEvent(PostEvent evt) {
+    String zkey = "popular-posts";
+    double delta;
+    switch (evt.getType()) {
+      case VIEW:    delta = 1; break;
+      case LIKE:    delta = 5; break;
+      case COMMENT: delta = 3; break;
+      default:      delta = 0;
+    }
+    // postId를 문자열로 저장
+    String member = evt.getPostId().toString();
+    popularityRedisTemplate.opsForZSet()
+        .incrementScore(zkey, member, delta);
+  }
+}


### PR DESCRIPTION
Changes
---
- 조회(View), 좋아요(Like), 댓글(Comment) 이벤트를 Kafka로 발행
- Kafka Consumer에서 Redis SortedSet에 점수 누적 (VIEW=1, LIKE=5, COMMENT=3)
- 중복 조회 방지를 위해 Redis Set 활용
- `/api/posts/popular?size={N}` 엔드포인트로 Top‑N 인기 게시글 제공